### PR TITLE
Update the now deprecated URL for electron headers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = function build(command, opts, done) {
 
   let arch = opts.arch || process.arch;
 
-  let disturl = opts.disturl || "https://atom.io/download/electron";
+  let disturl = opts.disturl || "https://electronjs.org/headers";
 
   let devdir = opts.devdir || path.join(os.homedir(), ".electron-gyp");
 


### PR DESCRIPTION
The previous URL used (https://atom.io/download/electron) now redirects to (https://github.blog/2022-06-08-sunsetting-atom/) — to denote the EOL of Atom. This however means that old projects that still rely on this package now cannot be built.

To fix this one can simply change the default URL to `https://electronjs.org/headers` and have everything work as expected.